### PR TITLE
Rename object list

### DIFF
--- a/easy_list.h
+++ b/easy_list.h
@@ -8,11 +8,10 @@
 #include <algorithm>
 #include <template_helpers.h>
 
-
-namespace easylist
+namespace easy_list
 {
     template<class _Type, class _Alloc = std::allocator<_Type>>
-        class object_list : public std::vector<_Type, _Alloc>
+    class list : public std::vector<_Type, _Alloc>
     {
     public:
         using _Mybase = std::vector<_Type>;
@@ -20,65 +19,63 @@ namespace easylist
         using allocator_type = typename _Mybase::allocator_type;
         using size_type = typename _Mybase::size_type;
 
-
-
         ////////////////////
         /// CONSTRUCTORS ///
         ////////////////////
 
-        object_list() : _Mybase() {}
+        list() : _Mybase() {}
 
-        explicit object_list(const _Alloc& _Al) : _Mybase(_Al) {}
+        explicit list(const _Alloc& _Al) : _Mybase(_Al) {}
 
-        object_list(const _Mybase& _Right, const _Alloc& _Al = _Alloc()) : _Mybase(_Right, _Al) {}
+        list(const _Mybase& _Right, const _Alloc& _Al = _Alloc()) : _Mybase(_Right, _Al) {}
 
-        object_list(const size_t _Count, const _Type& _Val, const _Alloc& _Al = _Alloc()) : _Mybase(_Count, _Val, _Al) {}
+        list(const size_t _Count, const _Type& _Val, const _Alloc& _Al = _Alloc()) : _Mybase(_Count, _Val, _Al) {}
 
         template <class _Iter, std::enable_if_t<std::_Is_iterator_v<_Iter>, bool> = true>
-        object_list(_Iter _First, _Iter _Last, const _Alloc& _Al = _Alloc()) : _Mybase(_First, _Last, _Al) {}
+        list(_Iter _First, _Iter _Last, const _Alloc& _Al = _Alloc()) : _Mybase(_First, _Last, _Al) {}
 
-        object_list(object_list&& _Right, const _Alloc& _Al = _Alloc()) noexcept : _Mybase((_Mybase&&)_Right, _Al) {}
+        list(list&& _Right, const _Alloc& _Al = _Alloc()) noexcept : _Mybase((_Mybase&&)_Right, _Al) {}
 
-        object_list(_Mybase&& _Right, const _Alloc& _Al = _Alloc()) noexcept : _Mybase(_Right, _Al) {}
+        list(_Mybase&& _Right, const _Alloc& _Al = _Alloc()) noexcept : _Mybase(_Right, _Al) {}
 
-        object_list(std::initializer_list<_Type> _Ilist, const _Alloc& _Al = _Alloc()) : _Mybase(_Ilist, _Al) {}
+        list(std::initializer_list<_Type> _Ilist, const _Alloc& _Al = _Alloc()) : _Mybase(_Ilist, _Al) {}
 
-        object_list(const object_list& _Right, const _Alloc& _Al = _Alloc()) : _Mybase((const _Mybase&)_Right, _Al) {}
+        list(const list& _Right, const _Alloc& _Al = _Alloc()) : _Mybase((const _Mybase&)_Right, _Al) {}
 
-        ~object_list() { }
+        ~list() { }
 
 
         //////////////////////////
         /// OPERATOR OVERLOADS ///
         //////////////////////////
 
-        object_list& operator=(const object_list& _Right) {
+        list& operator=(const list& _Right) {
             return _Mybase::operator=((const _Mybase&)_Right);
         }
 
-        object_list& operator=(object_list&& _Right) noexcept {
+        list& operator=(list&& _Right) noexcept {
             _Mybase::operator=((_Mybase&&)_Right);
             return *this;
         }
 
-        template <std::enable_if_t<can_convert_string_v<_Type>, bool> = true>
+        template <std::enable_if_t<template_helpers::can_convert_string_v<_Type>, bool> = true>
         operator std::string() const
         {
 
-            std::string str = "object_list<";
+            std::string str = "easy_list::list<";
             str += typeid(_Type).name();
             str += ">: (";
             if (_Mybase::size() != 0)
             {
                 for (_Type elem : *this)
-                    str += convert_string(elem) + ", ";
+                    str += template_helpers::convert_string(elem) + ", ";
                 str = str.substr(0, str.length() - 2);
             }
             str += ")";
             return str;
         }
 
-        friend std::ostream& operator<<(std::ostream& output, const object_list& list)
+        friend std::ostream& operator<<(std::ostream& output, const list& list)
         {
             std::string str = list;
             output << str;
@@ -90,7 +87,7 @@ namespace easylist
         /// SEARCHING ///
         /////////////////
 
-        template <std::enable_if_t<is_equatable_self_v<_Type>, bool> = true>
+        template <std::enable_if_t<template_helpers::is_equatable_self_v<_Type>, bool> = true>
         typename _Mybase::iterator search(const _Type match)
         {
             return std::find(this->begin(), this->end(), match);
@@ -101,12 +98,13 @@ namespace easylist
             std::enable_if_t<
                 std::conjunction_v<
                     std::negation<std::is_same<_Type, _MatchType>>,
-                    is_equatable<_Type, _MatchType>
+                    template_helpers::is_equatable<_Type, _MatchType>
                 >,
                 bool
-            > = true
+            >
+            = true
         >
-        typename _Mybase::iterator search(const _MatchType match)
+            typename _Mybase::iterator search(const _MatchType match)
         {
             return std::find(this->begin(), this->end(), [match](_Type other) -> bool { return other == match; });
         }
@@ -116,11 +114,12 @@ namespace easylist
             std::enable_if_t<
                 std::conjunction_v<
                     std::negation<std::is_same<_Type, _Predicate>>,
-                    std::negation<is_equatable<_Type, _Predicate>>,
-                    is_predicate<_Predicate, _Type>
+                    std::negation<template_helpers::is_equatable<_Type, _Predicate>>,
+                    template_helpers::is_predicate<_Predicate, _Type>
                 >,
                 bool
-            > = true
+            >
+            = true
         >
         typename _Mybase::iterator search(_Predicate predicate)
         {
@@ -134,7 +133,8 @@ namespace easylist
             std::enable_if_t<
                 std::is_invocable_r_v<_Result, decltype(std::declval<_Callable>()), _Type, _Args...>,
                 bool
-            > = true
+            >
+            = true
         >
         typename _Mybase::iterator search(_Result match, _Callable member, const _Args&... args)
         {
@@ -151,10 +151,14 @@ namespace easylist
         /// SORTING ///
         ///////////////
 
-        template <typename _Compare, std::enable_if_t<is_comparison_v<_Compare, _Type>, bool> = true>
+        template <typename _Compare, std::enable_if_t<template_helpers::is_comparison_v<_Compare, _Type>, bool> = true>
         void sort(_Compare comparer)
         {
-            std::sort(this->begin(), this->end(), cast_static_comparison<_Compare, _Type>(comparer));
+            std::sort(
+                this->begin(),
+                this->end(),
+                template_helpers::cast_static_comparison<_Compare, _Type>(comparer)
+            );
         }
 
         void sort()
@@ -169,15 +173,16 @@ namespace easylist
             typename _Result = std::remove_reference_t<decltype(std::invoke(std::declval<_Callable>(), std::declval<_Type>(), std::declval<_Args>()...))>,
             std::enable_if_t<
                 std::conjunction_v<
-                    is_comparison<_Compare, _Result>,
-                    is_const_member_of<_Callable, _Type, _Args...>
+                    template_helpers::is_comparison<_Compare, _Result>,
+                    template_helpers::is_const_member_of<_Callable, _Type, _Args...>
                 >,
                 bool
-            > = true
+            >
+            = true
         >
         void sort(_Compare comparer, _Callable member, const _Args&... args)
         {
-            static auto static_comparer = cast_static_comparison<_Compare, _Type>(comparer);
+            static auto static_comparer = template_helpers::cast_static_comparison<_Compare, _Type>(comparer);
             static auto pred = [comparer, member, args...](const _Type& lhs, const _Type& rhs) -> auto {
                 const _Result resultLhs = std::invoke(member, lhs, args...);
                 const _Result resultRhs = std::invoke(member, rhs, args...);
@@ -200,10 +205,10 @@ namespace easylist
         /// SELECTING ///
         /////////////////
 
-        template <std::enable_if_t<is_equatable_self_v<_Type>, bool> = true>
-        object_list select(const _Type match)
+        template <std::enable_if_t<template_helpers::is_equatable_self_v<_Type>, bool> = true>
+        list select(const _Type match)
         {
-            object_list sublist = object_list();
+            list sublist = list();
             for (_Type elem : *this)
             {
                 if (elem == match)
@@ -217,14 +222,15 @@ namespace easylist
             std::enable_if_t<
                 std::conjunction_v<
                     std::negation<std::is_same<_Type, _MatchType>>,
-                    is_equatable<_Type, _MatchType>
+                    template_helpers::is_equatable<_Type, _MatchType>
                 >,
                 bool
-            > = true
+            >
+            = true
         >
-        object_list select(const _MatchType match)
+        list select(const _MatchType match)
         {
-            object_list sublist = object_list();
+            list sublist = list();
             for (_Type elem : *this)
             {
                 if (elem == match)
@@ -238,15 +244,16 @@ namespace easylist
             std::enable_if_t<
                 std::conjunction_v<
                     std::negation<std::is_same<_Type, _Predicate>>,
-                    std::negation<is_equatable<_Type, _Predicate>>,
-                    is_predicate<_Predicate, _Type>
+                    std::negation<template_helpers::is_equatable<_Type, _Predicate>>,
+                    template_helpers::is_predicate<_Predicate, _Type>
                 >,
                 bool
-            > = true
+            >
+            = true
         >
-        object_list select(_Predicate predicate)
+        list select(_Predicate predicate)
         {
-            object_list sublist = object_list();
+            list sublist = list();
             for (_Type elem : *this)
             {
                 if (predicate(elem))
@@ -264,11 +271,12 @@ namespace easylist
                     std::is_member_pointer<_Callable>,
                     std::is_invocable_r<_Result, decltype(std::declval<_Callable>()), _Type, _Args...>
                 >, bool
-            > = true
+            >
+            = true
         >
-        object_list select(_Result match, _Callable member, const _Args&... args)
+        list select(_Result match, _Callable member, const _Args&... args)
         {
-            object_list sublist = object_list();
+            list sublist = list();
             for (_Type elem : *this)
             {
                 if (std::invoke(member, elem, args...) == match)
@@ -290,12 +298,14 @@ namespace easylist
                 std::conjunction_v<
                     std::negation<std::is_member_pointer<_Transformer>>,
                     std::is_invocable_r<_Result, decltype(std::declval<_Transformer>()), _Type, _Args...>
-                >, bool
-            > = true
+                >,
+                bool
+            >
+            = true
         >
-        object_list<_Result> transform(_Transformer transformer, _Args... args)
+        list<_Result> transform(_Transformer transformer, _Args... args)
         {
-            object_list<_Result> result = object_list<_Result>();
+            list<_Result> result = list<_Result>();
             for (_Type elem : *this)
                 result.push_back(transformer(elem, args...));
             return result;
@@ -308,16 +318,18 @@ namespace easylist
             std::enable_if_t<
                 std::conjunction_v<
                     std::is_member_pointer<_Callable>,
-                    std::is_invocable_r<_Result, decltype(std::declval<_Callable>()), _Type, _Args...>
-                >, bool
-            > = true
+                   std::is_invocable_r<_Result, decltype(std::declval<_Callable>()), _Type, _Args...>
+                >,
+                bool
+            >
+            = true
         >
-        object_list<_Result> transform(_Callable member, _Args... args)
+        list<_Result> transform(_Callable member, _Args... args)
         {
             static auto transformer = [member](_Type obj, _Args... args)->_Result {
                 return std::invoke(member, obj, args...);
             };
-            object_list<_Result> result = object_list<_Result>();
+            list<_Result> result = list<_Result>();
             for (_Type elem : *this)
                 result.push_back(transformer(elem, args...));
             return result;

--- a/easy_list.h
+++ b/easy_list.h
@@ -152,18 +152,20 @@ namespace easy_list
         ///////////////
 
         template <typename _Compare, std::enable_if_t<template_helpers::is_comparison_v<_Compare, _Type>, bool> = true>
-        void sort(_Compare comparer)
+        object_list& sort(_Compare comparer)
         {
             std::sort(
                 this->begin(),
                 this->end(),
                 template_helpers::cast_static_comparison<_Compare, _Type>(comparer)
             );
+            return *this;
         }
 
-        void sort()
+        object_list& sort()
         {
             this->sort(std::less<>{});
+            return *this;
         }
 
         template <
@@ -180,7 +182,7 @@ namespace easy_list
             >
             = true
         >
-        void sort(_Compare comparer, _Callable member, const _Args&... args)
+        object_list& sort(_Compare comparer, _Callable member, const _Args&... args)
         {
             inline auto static_comparer = template_helpers::cast_static_comparison<_Compare, _Type>(comparer);
             auto pred = [static_comparer, member, args...](const _Type& lhs, const _Type& rhs) -> auto {
@@ -189,15 +191,17 @@ namespace easy_list
                 return static_comparer(resultLhs, resultRhs);
             };
             std::sort(this->begin(), this->end(), pred);
+            return *this;
         }
 
         template <
             typename _Callable,
             typename... _Args
         >
-        void sort(_Callable member, const _Args&... args)
+        object_list& sort(_Callable member, const _Args&... args)
         {
             this->sort(std::less<>{}, member, args...);
+            return *this;
         }
 
 

--- a/easy_list.h
+++ b/easy_list.h
@@ -182,8 +182,8 @@ namespace easy_list
         >
         void sort(_Compare comparer, _Callable member, const _Args&... args)
         {
-            static auto static_comparer = template_helpers::cast_static_comparison<_Compare, _Type>(comparer);
-            static auto pred = [comparer, member, args...](const _Type& lhs, const _Type& rhs) -> auto {
+            inline auto static_comparer = template_helpers::cast_static_comparison<_Compare, _Type>(comparer);
+            auto pred = [static_comparer, member, args...](const _Type& lhs, const _Type& rhs) -> auto {
                 const _Result resultLhs = std::invoke(member, lhs, args...);
                 const _Result resultRhs = std::invoke(member, rhs, args...);
                 return static_comparer(resultLhs, resultRhs);

--- a/easy_list.h
+++ b/easy_list.h
@@ -152,7 +152,7 @@ namespace easy_list
         ///////////////
 
         template <typename _Compare, std::enable_if_t<template_helpers::is_comparison_v<_Compare, _Type>, bool> = true>
-        object_list& sort(_Compare comparer)
+        list& sort(_Compare comparer)
         {
             std::sort(
                 this->begin(),
@@ -162,7 +162,7 @@ namespace easy_list
             return *this;
         }
 
-        object_list& sort()
+        list& sort()
         {
             this->sort(std::less<>{});
             return *this;
@@ -182,7 +182,7 @@ namespace easy_list
             >
             = true
         >
-        object_list& sort(_Compare comparer, _Callable member, const _Args&... args)
+        list& sort(_Compare comparer, _Callable member, const _Args&... args)
         {
             inline auto static_comparer = template_helpers::cast_static_comparison<_Compare, _Type>(comparer);
             auto pred = [static_comparer, member, args...](const _Type& lhs, const _Type& rhs) -> auto {
@@ -198,7 +198,7 @@ namespace easy_list
             typename _Callable,
             typename... _Args
         >
-        object_list& sort(_Callable member, const _Args&... args)
+        list& sort(_Callable member, const _Args&... args)
         {
             this->sort(std::less<>{}, member, args...);
             return *this;

--- a/easy_list.h
+++ b/easy_list.h
@@ -88,7 +88,7 @@ namespace easy_list
         /////////////////
 
         template <std::enable_if_t<template_helpers::is_equatable_self_v<_Type>, bool> = true>
-        typename _Mybase::iterator search(const _Type match)
+        [[nodiscard]] typename _Mybase::iterator search(const _Type match)
         {
             return std::find(this->begin(), this->end(), match);
         }
@@ -104,7 +104,7 @@ namespace easy_list
             >
             = true
         >
-            typename _Mybase::iterator search(const _MatchType match)
+        [[nodiscard]] typename _Mybase::iterator search(const _MatchType match)
         {
             return std::find(this->begin(), this->end(), [match](_Type other) -> bool { return other == match; });
         }
@@ -121,7 +121,7 @@ namespace easy_list
             >
             = true
         >
-        typename _Mybase::iterator search(_Predicate predicate)
+        [[nodiscard]] typename _Mybase::iterator search(_Predicate predicate)
         {
             return std::find_if(this->begin(), this->end(), predicate);
         }
@@ -136,7 +136,7 @@ namespace easy_list
             >
             = true
         >
-        typename _Mybase::iterator search(_Result match, _Callable member, const _Args&... args)
+        [[nodiscard]] typename _Mybase::iterator search(_Result match, _Callable member, const _Args&... args)
         {
             return std::find_if(
                 this->begin(),
@@ -210,7 +210,7 @@ namespace easy_list
         /////////////////
 
         template <std::enable_if_t<template_helpers::is_equatable_self_v<_Type>, bool> = true>
-        list select(const _Type match)
+        [[nodiscard]] list select(const _Type match)
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -232,7 +232,7 @@ namespace easy_list
             >
             = true
         >
-        list select(const _MatchType match)
+        [[nodiscard]] list select(const _MatchType match)
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -255,7 +255,7 @@ namespace easy_list
             >
             = true
         >
-        list select(_Predicate predicate)
+        [[nodiscard]] list select(_Predicate predicate)
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -278,7 +278,7 @@ namespace easy_list
             >
             = true
         >
-        list select(_Result match, _Callable member, const _Args&... args)
+        [[nodiscard]] list select(_Result match, _Callable member, const _Args&... args)
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -307,7 +307,7 @@ namespace easy_list
             >
             = true
         >
-        list<_Result> transform(_Transformer transformer, _Args... args)
+        [[nodiscard]] list<_Result> transform(_Transformer transformer, _Args... args)
         {
             list<_Result> result = list<_Result>();
             for (_Type elem : *this)
@@ -328,7 +328,7 @@ namespace easy_list
             >
             = true
         >
-        list<_Result> transform(_Callable member, _Args... args)
+        [[nodiscard]] list<_Result> transform(_Callable member, _Args... args)
         {
             static auto transformer = [member](_Type obj, _Args... args)->_Result {
                 return std::invoke(member, obj, args...);

--- a/easy_list.h
+++ b/easy_list.h
@@ -88,7 +88,7 @@ namespace easy_list
         /////////////////
 
         template <std::enable_if_t<template_helpers::is_equatable_self_v<_Type>, bool> = true>
-        [[nodiscard]] typename _Mybase::iterator search(const _Type match)
+        [[nodiscard]] typename _Mybase::iterator search(const _Type match) const
         {
             return std::find(this->begin(), this->end(), match);
         }
@@ -104,7 +104,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] typename _Mybase::iterator search(const _MatchType match)
+        [[nodiscard]] typename _Mybase::iterator search(const _MatchType match) const
         {
             return std::find(this->begin(), this->end(), [match](_Type other) -> bool { return other == match; });
         }
@@ -121,7 +121,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] typename _Mybase::iterator search(_Predicate predicate)
+        [[nodiscard]] typename _Mybase::iterator search(_Predicate predicate) const
         {
             return std::find_if(this->begin(), this->end(), predicate);
         }
@@ -136,7 +136,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] typename _Mybase::iterator search(_Result match, _Callable member, const _Args&... args)
+        [[nodiscard]] typename _Mybase::iterator search(_Result match, _Callable member, const _Args&... args) const
         {
             return std::find_if(
                 this->begin(),
@@ -210,7 +210,7 @@ namespace easy_list
         /////////////////
 
         template <std::enable_if_t<template_helpers::is_equatable_self_v<_Type>, bool> = true>
-        [[nodiscard]] list select(const _Type match)
+        [[nodiscard]] list select(const _Type match) const
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -232,7 +232,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] list select(const _MatchType match)
+        [[nodiscard]] list select(const _MatchType match) const
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -255,7 +255,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] list select(_Predicate predicate)
+        [[nodiscard]] list select(_Predicate predicate) const
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -278,7 +278,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] list select(_Result match, _Callable member, const _Args&... args)
+        [[nodiscard]] list select(_Result match, _Callable member, const _Args&... args) const
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -307,7 +307,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] list<_Result> transform(_Transformer transformer, _Args... args)
+        [[nodiscard]] list<_Result> transform(_Transformer transformer, _Args... args) const
         {
             list<_Result> result = list<_Result>();
             for (_Type elem : *this)
@@ -328,7 +328,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] list<_Result> transform(_Callable member, _Args... args)
+        [[nodiscard]] list<_Result> transform(_Callable member, _Args... args) const
         {
             static auto transformer = [member](_Type obj, _Args... args)->_Result {
                 return std::invoke(member, obj, args...);

--- a/easylist.h
+++ b/easylist.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#include "object_list.h"

--- a/easylist.vcxproj
+++ b/easylist.vcxproj
@@ -145,8 +145,7 @@
     <ClCompile Include="tester.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="easylist.h" />
-    <ClInclude Include="object_list.h" />
+    <ClInclude Include="easy_list.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/easylist.vcxproj.filters
+++ b/easylist.vcxproj.filters
@@ -20,10 +20,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="easylist.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="object_list.h">
+    <ClInclude Include="easy_list.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/tester.cpp
+++ b/tester.cpp
@@ -2,9 +2,9 @@
 //
 
 #include <iostream>
-#include "easylist.h"
+#include "easy_list.h"
 
-using namespace easylist;
+using namespace easy_list;
 
 class C
 {
@@ -33,17 +33,10 @@ int main()
     const C c = C(1);
     c.getDiff(0);
 
-    object_list<C> cList = object_list<C>({ C(0), C(2), C(-3) });
+    list<C> cList = list<C>({ C(0), C(2), C(-3) });
 
-    std::cout << cList.transform<C>(plusOne) << std::endl;
-
-    std::cout << cList.transform<C>(plusN, -1) << std::endl;
-
-    std::cout << cList.transform<int>(&C::n) << std::endl;
-
-    std::cout << cList.transform<int>(&C::get) << std::endl;
-
-    std::cout << cList.transform<int>(&C::getDiff, 0) << std::endl;
+    cList.sort();
+    std::cout << cList << std::endl;
 
     return 0;
 }

--- a/tester.cpp
+++ b/tester.cpp
@@ -35,7 +35,8 @@ int main()
 
     list<C> cList = list<C>({ C(0), C(2), C(-3) });
 
-    cList.search(C(0));
+    std::cout << cList.sort().sort(&C::operator>) << std::endl;
+    std::cout << cList << std::endl;
 
     return 0;
 }

--- a/tester.cpp
+++ b/tester.cpp
@@ -35,8 +35,7 @@ int main()
 
     list<C> cList = list<C>({ C(0), C(2), C(-3) });
 
-    cList.sort();
-    std::cout << cList << std::endl;
+    cList.search(C(0));
 
     return 0;
 }


### PR DESCRIPTION
Renames namespace <code>easylist</code> to <code>easy_list</code>, and <code>object_list</code> to <code>list</code>. Also does some miscellaneous tidying up.