### PR TITLE
Don't pass by ref unnecessarily

### DIFF
--- a/easy_list.h
+++ b/easy_list.h
@@ -497,18 +497,6 @@ namespace easy_list
             return result;
         }
 
-        /// Unify ///
-        [[nodiscard]] list unify(const _Mybase rhs) const
-        {
-            list<_Type, _Alloc> result = list<_Type, _Alloc>();
-            for (_Type elem : *this + rhs)
-            {
-                if (!result.contains(elem))
-                    result.push_back(elem);
-            }
-            return result;
-        }
-
 
         ///////////////
         /// REPLACE ///
@@ -717,6 +705,18 @@ namespace easy_list
                 if (std::invoke(member, elem, args...) == match)
                     result.push_back(std::invoke(transformer, elem));
                 else
+                    result.push_back(elem);
+            }
+            return result;
+        }
+
+        /// Unify ///
+        [[nodiscard]] list unify(const _Mybase rhs) const
+        {
+            list<_Type, _Alloc> result = list<_Type, _Alloc>();
+            for (_Type elem : *this + rhs)
+            {
+                if (!result.contains(elem))
                     result.push_back(elem);
             }
             return result;

--- a/easy_list.h
+++ b/easy_list.h
@@ -100,7 +100,7 @@ namespace easy_list
             return str;
         }
 
-        friend std::ostream& operator<<(std::ostream& output, const list& list)
+        friend std::ostream& operator<<(std::ostream& output, const list list)
         {
             std::string str = list;
             output << str;
@@ -150,7 +150,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] typename _Mybase::const_iterator search(const _Predicate& predicate) const
+        [[nodiscard]] typename _Mybase::const_iterator search(const _Predicate predicate) const
         {
             return std::find_if(this->begin(), this->end(), predicate);
         }
@@ -165,7 +165,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] typename _Mybase::const_iterator search(const _Result& match, const _Callable& member, const _Args&... args) const
+        [[nodiscard]] typename _Mybase::const_iterator search(const _Result& match, const _Callable member, const _Args&... args) const
         {
             return std::find_if(
                 this->begin(),
@@ -214,7 +214,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] bool contains(const _Predicate& predicate) const
+        [[nodiscard]] bool contains(const _Predicate predicate) const
         {
             return this->search(predicate) != this->npos();
         }
@@ -229,7 +229,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] bool contains(const _Result& match, const _Callable& member, const _Args&... args) const
+        [[nodiscard]] bool contains(const _Result& match, const _Callable member, const _Args&... args) const
         {
             return this->search(match, member, args...) != this->npos();
         }
@@ -240,7 +240,7 @@ namespace easy_list
         ///////////////
 
         template <typename _Compare, std::enable_if_t<template_helpers::is_comparison_v<_Compare, _Type>, bool> = true>
-        list& sort(const _Compare& comparer)
+        list& sort(const _Compare comparer)
         {
             std::sort(
                 this->begin(),
@@ -270,7 +270,7 @@ namespace easy_list
             >
             = true
         >
-        list& sort(const _Compare& comparer, const _Callable& member, const _Args&... args)
+        list& sort(const _Compare comparer, const _Callable member, const _Args&... args)
         {
             inline auto static_comparer = template_helpers::cast_static_comparison<_Compare, _Type>(comparer);
             auto pred = [static_comparer, member, args...](const _Type& lhs, const _Type& rhs) -> auto {
@@ -286,7 +286,7 @@ namespace easy_list
             typename _Callable,
             typename... _Args
         >
-        list& sort(const _Callable& member, const _Args&... args)
+        list& sort(const _Callable member, const _Args&... args)
         {
             this->sort(std::less<>{}, member, args...);
             return *this;
@@ -343,7 +343,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] list select(const _Predicate& predicate) const
+        [[nodiscard]] list select(const _Predicate predicate) const
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -366,7 +366,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] list select(const _Result& match, const _Callable& member, const _Args&... args) const
+        [[nodiscard]] list select(const _Result& match, const _Callable member, const _Args&... args) const
         {
             list sublist = list();
             for (_Type elem : *this)
@@ -416,7 +416,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] size_t count(const _Predicate& predicate) const
+        [[nodiscard]] size_t count(const _Predicate predicate) const
         {
             return this->select(predicate).size();
         }
@@ -433,7 +433,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] size_t count(const _Result& match, const _Callable& member, const _Args&... args) const
+        [[nodiscard]] size_t count(const _Result& match, const _Callable member, const _Args&... args) const
         {
             return this->select(match, member, args...).size();
         }
@@ -465,7 +465,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] list<_Result> transform(const _Transformer& transformer, const _Args&... args) const
+        [[nodiscard]] list<_Result> transform(const _Transformer transformer, const _Args&... args) const
         {
             list<_Result> result = list<_Result>();
             for (_Type elem : *this)
@@ -486,7 +486,7 @@ namespace easy_list
             >
             = true
         >
-        [[nodiscard]] list<_Result> transform(const _Callable& member, const _Args&... args) const
+        [[nodiscard]] list<_Result> transform(const _Callable member, const _Args&... args) const
         {
             static auto transformer = [member](const _Type& obj, const _Args&... args)->_Result {
                 return std::invoke(member, obj, args...);

--- a/easy_list.h
+++ b/easy_list.h
@@ -577,7 +577,7 @@ namespace easy_list
                 bool
             > = true
         >
-        [[nodiscard]] list replace(_Replacer replacement, const _Predicate& predicate) const
+        [[nodiscard]] list replace(_Replacer replacement, const _Predicate predicate) const
         {
             list result = list();
             for (_Type elem : *this)
@@ -603,7 +603,7 @@ namespace easy_list
                 >, bool
             > = true
         >
-        [[nodiscard]] list replace(_Replacer replacement, const _Result& match, const _Callable& member, const _Args&... args) const
+        [[nodiscard]] list replace(_Replacer replacement, const _Result& match, const _Callable member, const _Args&... args) const
         {
             list result = list();
             for (_Type elem : *this)
@@ -682,7 +682,7 @@ namespace easy_list
                 bool
             > = true
         >
-        [[nodiscard]] list replace(const _Transformer transformer, const _Predicate& predicate) const
+        [[nodiscard]] list replace(const _Transformer transformer, const _Predicate predicate) const
         {
             list result = list();
             for (_Type elem : *this)
@@ -709,7 +709,7 @@ namespace easy_list
                 >, bool
             > = true
         >
-        [[nodiscard]] list replace(const _Transformer transformer, const _Result& match, const _Callable& member, const _Args&... args) const
+        [[nodiscard]] list replace(const _Transformer transformer, const _Result& match, const _Callable member, const _Args&... args) const
         {
             list result = list();
             for (_Type elem : *this)


### PR DESCRIPTION
Passing by ref when not really required can cause some unnecessary headaches. So, passing by ref is now only done when it could conceivably be useful (e.g. comparing things for equality - passing objects by value may make equality checks fail when they are expected to pass).